### PR TITLE
Add sdk key functionality

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@ const express = require("express");
 const morgan = require("morgan");
 const routes = require("./routes/index.js");
 const { fetchFlags } = require("./lib/flags.js");
+const { fetchKey } = require("./lib/key.js");
 
 const app = express();
 const PORT = 5050;
@@ -15,15 +16,14 @@ app.use((req, res, next) => {
   next();
 });
 
-// const flags = getFlags();
 app.use(morgan("tiny"));
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 
-// Get the flags on initial boot
+// Get the data from FF manager on initial boot
 fetchFlags();
+fetchKey();
 
-// routes
 app.use("/", routes);
 
 // Error handler

--- a/controllers/flagsController.js
+++ b/controllers/flagsController.js
@@ -1,20 +1,14 @@
-const { get } = require("express/lib/request");
-const { type } = require("express/lib/response");
 const { setFlags, returnFlags } = require("../lib/flags.js");
-const { sendToClients } = require('./streamController');
-/*
-TODO: Validate that the POST request is from the FF manager
-TODO: Add persistant flag data.
-*/
+const { sendToClients } = require("./streamController");
 
 async function replaceFlags(req, res, next) {
   try {
     setFlags(req.body);
     sendToClients();
-    res.status(200).send("Received");
+    res.status(200).send({ message: "Received" });
   } catch (err) {
     console.log(err.message);
-    res.status(500).send("Error saving flags");
+    res.status(500).send({ message: "Error saving flags" });
   }
 }
 
@@ -22,7 +16,7 @@ async function getFlags(req, res, next) {
   try {
     res.status(200).send(returnFlags());
   } catch (err) {
-    res.status(500).send("Error getting flags");
+    res.status(500).send({ message: "Error getting flags" });
   }
 }
 

--- a/controllers/keyController.js
+++ b/controllers/keyController.js
@@ -1,0 +1,26 @@
+const { setKey, returnKey } = require("../lib/key");
+
+async function replaceKey(req, res, next) {
+  try {
+    setKey(req.body.key);
+    res.status(200).send("Received");
+  } catch (err) {
+    console.log(err.message);
+    res.status(500).send({ message: "Error sending key" });
+  }
+}
+
+async function validateKey(req, res, next) {
+  const requestKey = req.query.sdk_key;
+
+  if (requestKey !== returnKey()) {
+    res.status(500).send({
+      message: "Invalid sdk key",
+    });
+  } else {
+    next();
+  }
+}
+
+module.exports.replaceKey = replaceKey;
+module.exports.validateKey = validateKey;

--- a/controllers/keyController.js
+++ b/controllers/keyController.js
@@ -3,7 +3,7 @@ const { setKey, returnKey } = require("../lib/key");
 async function replaceKey(req, res, next) {
   try {
     setKey(req.body.key);
-    res.status(200).send("Received");
+    res.status(200).send({ message: "Received" });
   } catch (err) {
     console.log(err.message);
     res.status(500).send({ message: "Error sending key" });

--- a/controllers/streamController.js
+++ b/controllers/streamController.js
@@ -10,7 +10,7 @@ const handleNewConnection = async (req, res) => {
     "Cache-Control": "no-cache",
   };
 
-  console.log("user connected");
+  console.log("New user connected");
 
   res.writeHead(200, headers);
 

--- a/lib/flags.js
+++ b/lib/flags.js
@@ -5,7 +5,9 @@ let flags = [];
 
 async function fetchFlags() {
   try {
-    const response = await axios.get(process.env.FEATURE_FLAG_MANAGER_URL);
+    const response = await axios.get(
+      `${process.env.FEATURE_FLAG_MANAGER_URL}/api/flags?prov=true`
+    );
     flags = response.data;
   } catch (err) {
     console.log("Could not get flags from waypost server");

--- a/lib/key.js
+++ b/lib/key.js
@@ -1,0 +1,27 @@
+const axios = require("axios");
+require("dotenv").config();
+
+let key = "";
+
+async function fetchKey() {
+  try {
+    const response = await axios.get(
+      `${process.env.FEATURE_FLAG_MANAGER_URL}/api/sdkKey`
+    );
+    key = response.data;
+  } catch (err) {
+    console.log("Could not get key from waypost server");
+  }
+}
+
+function setKey(newKey) {
+  key = newKey;
+}
+
+function returnKey() {
+  return key;
+}
+
+module.exports.fetchKey = fetchKey;
+module.exports.setKey = setKey;
+module.exports.returnKey = returnKey;

--- a/routes/index.js
+++ b/routes/index.js
@@ -3,11 +3,18 @@ const router = express.Router();
 
 const flagsController = require("../controllers/flagsController");
 const streamController = require("../controllers/streamController");
+const keyController = require("../controllers/keyController");
+
+router.post("/key", keyController.replaceKey);
 
 router.post("/flags", flagsController.replaceFlags);
 
-router.get("/flags", flagsController.getFlags);
+router.get("/flags", keyController.validateKey, flagsController.getFlags);
 
-router.get("/stream", streamController.handleNewConnection);
+router.get(
+  "/stream",
+  keyController.validateKey,
+  streamController.handleNewConnection
+);
 
 module.exports = router;


### PR DESCRIPTION
Here's what was added:

- A new route that handles the SDK key webhook and saves it to a variable
- A new middleware that looks at the query string of an incoming request and compares it to the saved sdk key. If it does not match, then an error is sent back. This middleware is on the /stream and GET /flags routes.
- Changed error messages to objects for consistency.

NOTE: I have not tested the new additions with the sdk yet (/stream route), but everything works as far as I can tell.